### PR TITLE
Remove deprecated Symfony\Component\Messenger\Handler\MessageHandlerI…

### DIFF
--- a/doc/Common-Bundle-Changelog/Unreleased.md
+++ b/doc/Common-Bundle-Changelog/Unreleased.md
@@ -4,5 +4,6 @@ planned
 ### Added
 
 ### Changed
+- Remove deprecated Symfony\Component\Messenger\Handler\MessageHandlerInterface from message handlers.
 
 ### Removed

--- a/src/Messenger/Handler/AppLogMessageHandler.php
+++ b/src/Messenger/Handler/AppLogMessageHandler.php
@@ -6,9 +6,8 @@ namespace AnzuSystems\CommonBundle\Messenger\Handler;
 
 use AnzuSystems\CommonBundle\Messenger\Message\AppLogMessage;
 use Symfony\Bridge\Monolog\Logger;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 
-final class AppLogMessageHandler implements MessageHandlerInterface
+final class AppLogMessageHandler
 {
     public function __construct(
         private readonly Logger $appSyncLogger,

--- a/src/Messenger/Handler/AuditLogMessageHandler.php
+++ b/src/Messenger/Handler/AuditLogMessageHandler.php
@@ -6,9 +6,8 @@ namespace AnzuSystems\CommonBundle\Messenger\Handler;
 
 use AnzuSystems\CommonBundle\Messenger\Message\AuditLogMessage;
 use Symfony\Bridge\Monolog\Logger;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 
-final class AuditLogMessageHandler implements MessageHandlerInterface
+final class AuditLogMessageHandler
 {
     public function __construct(
         private readonly Logger $auditSyncLogger,


### PR DESCRIPTION
…nterface from message handlers.

Deprecated in https://github.com/symfony/symfony/issues/43705 . 